### PR TITLE
Enhance landing page module

### DIFF
--- a/landing-page/README.md
+++ b/landing-page/README.md
@@ -1,0 +1,16 @@
+# Landing Page Module
+
+This Foundry VTT module displays a landing page with multiple pages. Each user can navigate between pages independently. The module tracks the page index using user flags so that players see only the page they have selected.
+
+The landing page includes additional pages for quick access to your Character Sheet, Inventory and a form to send private notes to the DM.
+
+## Installation
+
+1. Copy the `landing-page` folder into your Foundry VTT `modules` directory.
+2. Restart Foundry VTT and enable the module in Game Settings.
+
+## Usage
+
+Upon loading into a world, the landing page will appear automatically. Use the **Next** and **Previous** buttons to switch pages. The page you select is stored individually and will not affect what other players see.
+
+From the Character Sheet and Inventory pages you can open your actor's sheet directly. The "Notizen an den DM" page lets you send a whispered chat message to all GMs.

--- a/landing-page/module.json
+++ b/landing-page/module.json
@@ -1,0 +1,18 @@
+{
+  "name": "landing-page",
+  "title": "Landing Page Module",
+  "description": "A module that displays a landing page with individual pages per player.",
+  "author": "Dev-Xagon",
+  "version": "0.2.0",
+  "minimumCoreVersion": "0.8.0",
+  "compatibleCoreVersion": "11",
+  "scripts": ["scripts/landing-page.js"],
+  "esmodules": [],
+  "styles": [],
+  "packs": [],
+  "languages": [],
+  "dependencies": [],
+  "socket": false,
+  "manifest": "https://example.com/landing-page/module.json",
+  "download": "https://example.com/landing-page/module.zip"
+}

--- a/landing-page/scripts/landing-page.js
+++ b/landing-page/scripts/landing-page.js
@@ -1,0 +1,115 @@
+class LandingPageApp extends Application {
+  static get defaultOptions() {
+    return mergeObject(super.defaultOptions, {
+      id: "landing-page-app",
+      template: "modules/landing-page/templates/landing-page.html",
+      title: "Landing Page",
+      width: 600,
+      height: "auto"
+    });
+  }
+
+  constructor(options={}) {
+    super(options);
+    // Define the pages shown in the landing app
+    this.pages = [
+      {title: "Welcome", content: "<p>Welcome to the game!</p>"},
+      {title: "Rules", content: "<p>Here are some rules...</p>"},
+      {title: "Credits", content: "<p>Credits to the team...</p>"},
+      {
+        title: "Charactersheet",
+        content:
+          "<p><button type='button' class='open-character'>Open your Character Sheet</button></p>"
+      },
+      {
+        title: "Inventory",
+        content:
+          "<p><button type='button' class='open-inventory'>Open your Inventory</button></p>"
+      },
+      {
+        title: "Notizen an den DM",
+        content:
+          "<textarea class='note-dm' rows='4' cols='40' placeholder='Write a note to the DM'></textarea><br/><button type='button' class='send-dm'>Send to DM</button>"
+      }
+    ];
+  }
+
+  /**
+   * Retrieve the current page index from the user's flags.
+   */
+  get pageIndex() {
+    return game.user.getFlag("landing-page", "pageIndex") || 0;
+  }
+
+  /**
+   * Store the current page index for this user.
+   */
+  async setPageIndex(index) {
+    await game.user.setFlag("landing-page", "pageIndex", index);
+    this.render(true);
+  }
+
+  /**
+   * Provide data for the Handlebars template.
+   */
+  getData() {
+    return {
+      pages: this.pages,
+      current: this.pageIndex,
+      page: this.pages[this.pageIndex]
+    };
+  }
+
+  activateListeners(html) {
+    super.activateListeners(html);
+    const total = this.pages.length;
+
+    html.find("button.next").click(() => {
+      const next = (this.pageIndex + 1) % total;
+      this.setPageIndex(next);
+    });
+
+    html.find("button.prev").click(() => {
+      const prev = (this.pageIndex + total - 1) % total;
+      this.setPageIndex(prev);
+    });
+
+    html.find("button.open-character").click(() => {
+      if (game.user.character) {
+        game.user.character.sheet.render(true);
+      } else {
+        ui.notifications.warn("No character assigned to your user.");
+      }
+    });
+
+    html.find("button.open-inventory").click(() => {
+      const actor = game.user.character;
+      if (!actor) {
+        ui.notifications.warn("No character assigned to your user.");
+        return;
+      }
+      const sheet = actor.sheet;
+      sheet.render(true);
+      if (sheet._tabs) {
+        sheet._tabs[0].activate("inventory");
+      }
+    });
+
+    html.find("button.send-dm").click(async () => {
+      const textarea = html.find("textarea.note-dm");
+      const content = textarea.val();
+      if (!content) return;
+      await ChatMessage.create({
+        content,
+        whisper: ChatMessage.getWhisperRecipients("GM")
+      });
+      ui.notifications.info("Message sent to the GM.");
+      textarea.val("");
+    });
+  }
+}
+
+Hooks.once('ready', () => {
+  new LandingPageApp().render(true);
+});
+

--- a/landing-page/templates/landing-page.html
+++ b/landing-page/templates/landing-page.html
@@ -1,0 +1,8 @@
+<form class="landing-page">
+  <h2>{{page.title}}</h2>
+  <div class="content">{{{page.content}}}</div>
+  <div class="controls">
+    <button type="button" class="prev">Previous</button>
+    <button type="button" class="next">Next</button>
+  </div>
+</form>


### PR DESCRIPTION
## Summary
- extend landing page module with character sheet, inventory and DM note pages
- document new pages in README
- bump version in `module.json`

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684963de1aa483328765ca5cac59d96e